### PR TITLE
Issue 18 improve discrete coloring

### DIFF
--- a/R/catmaply.R
+++ b/R/catmaply.R
@@ -188,6 +188,9 @@ catmaply <- function(
     x_init_range <- 2
   }
 
+  if (categorical_colorbar && !legend)
+    warning("Parameter 'categorical_colorbar' and 'categorical_col' will be ignored if parameter 'legend' is FALSE")
+
   # preprocessing & logic
 
   # substitute hover_template if submitted; is_hover_template is a workaround

--- a/R/catmaply.R
+++ b/R/catmaply.R
@@ -230,6 +230,8 @@ catmaply <- function(
     stop("For each category needs to be exactly one color, if you use a colorbar, then two colors are needed for one category.")
   }
 
+  # create strucutre for following plots
+  # changes to this structure might affect traces
   df <- df %>%
     dplyr::mutate(
       x = !!rlang::sym(x),
@@ -255,9 +257,6 @@ catmaply <- function(
     fig <- fig %>%
       add_catmaply_traces(
         df=df,
-        x=x,
-        y=y,
-        z=z,
         hover_hide=hover_hide,
         categorical_colorbar=categorical_colorbar,
         category_items = category_items,
@@ -268,9 +267,6 @@ catmaply <- function(
     fig <- fig %>%
       add_catmaply_single(
         df=df,
-        x=x,
-        y=y,
-        z=z,
         hover_hide=hover_hide,
         categorical_colorbar=categorical_colorbar,
         legend_items=legend_items,

--- a/R/trace.R
+++ b/R/trace.R
@@ -153,5 +153,4 @@ add_catmaply_single <- function(
   }
 
   return(fig)
-
 }

--- a/R/trace.R
+++ b/R/trace.R
@@ -4,9 +4,6 @@
 #'
 #' @param fig plotly object
 #' @param df data.frame or tibble holding the data.
-#' @param x column name holding the axis values for x.
-#' @param y column name holding the axis values for y.
-#' @param z column name holding the values for the fields.
 #' @param hover_hide boolean indicating if the hover label should be hidden or not; (default: FALSE).
 #' @param color_palette a color palette vector.
 #' @param categorical_colorbar if the resulting heatmap holds categorical field values or continuous values that belong to a category; (default: FALSE).
@@ -22,9 +19,6 @@
 add_catmaply_traces <- function(
   fig,
   df,
-  x,
-  y,
-  z,
   hover_hide,
   color_palette,
   categorical_colorbar,
@@ -98,13 +92,7 @@ add_catmaply_traces <- function(
 #'
 #' @param fig plotly object
 #' @param df data.frame or tibble holding the data.
-#' @param x column name holding the axis values for x.
-#' @param y column name holding the axis values for y.
-#' @param z column name holding the values for the fields.
-#' @param hover_hide boolean indicating if the hover label should be hidden or not; (default: FALSE).
 #' @param color_palette a color palette vector.
-#' @param categorical_colorbar if the resulting heatmap holds categorical field values or continuous values that belong to a category; (default: FALSE).
-#' @param categorical_col if categorical_colorbar is TRUE, then this column is used to create categories; (default: FALSE).
 #' @param legend_items distinct/unique items of ordered legend items
 #' @param legend boolean indicating if legend should be displayed or not; (default: TRUE).
 #'
@@ -115,9 +103,6 @@ add_catmaply_traces <- function(
 add_catmaply_single <- function(
   fig,
   df,
-  x,
-  y,
-  z,
   hover_hide,
   color_palette,
   categorical_colorbar,
@@ -128,7 +113,9 @@ add_catmaply_single <- function(
   if (legend) {
     discrete_col <- discrete_coloring(
       categories=legend_items,
-      col_palette=color_palette
+      col_palette=color_palette,
+      range_min = min(stats::na.omit(df$z)),
+      range_max = max(stats::na.omit(df$z))
     )
 
     fig <- fig %>%
@@ -144,8 +131,8 @@ add_catmaply_single <- function(
         showlegend=FALSE,
         colorscale=discrete_col$colorscale,
         colorbar=list(
-          title="Legend",
-          len=0.5,
+          title="",
+          #len=0.5,
           tickvals=discrete_col$tickvals,
           ticktext=discrete_col$ticktext
         )

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,8 @@
 #'
 #' @param categories categories, for coloring should done
 #' @param col_palette the color palette
+#' @param range_min min of z range; (default: 1)
+#' @param range_min max of z range; (default: length(categories))
 #'
 #' @return list(colorscale, tickvals, ticktext)
 #'
@@ -10,14 +12,22 @@
 #' @keywords internal
 #'
 #' @export
-discrete_coloring <- function(categories, col_palette) {
+discrete_coloring <- function(categories, col_palette, range_min, range_max) {
+
+  if (!is.vector(categories))
+    stop("Parameter 'categories' must be a vector.")
+
+  if (!is.vector(col_palette))
+    stop("Parameter 'col_palette' must be a vector.")
+
+  discrete_colorbar <- F
+  if ((length(categories) * 2) == length(col_palette)) {
+    discrete_colorbar <- T
+  } else if (length(categories) != length(col_palette)) {
+    stop("Parameter 'col_palette' must have the same of twice the length of category parameter.")
+  }
 
   bvals <- c(0, seq.int(length.out = length(categories)))
-  pal <- col_palette
-
-  if (length(bvals) != (length(pal) + 1)) {
-    stop("length(bvals) should be equal to (length(pal) -1)")
-  }
 
   bvals <- bvals[order(bvals)]
   nvals <- (bvals - min(bvals)) / (max(bvals) - min(bvals))
@@ -26,19 +36,22 @@ discrete_coloring <- function(categories, col_palette) {
 
   for (i in seq.int(length.out = length(nvals) -1 )) {
     index <- ((i - 1) * 2) + 1
-    dcolorscale[index,] <- c(nvals[i], pal[i])
-    dcolorscale[index + 1,] <- c(nvals[i + 1], pal[i])
+    dcolorscale[index,] <- c(nvals[i], ifelse(discrete_colorbar, col_palette[index], col_palette[i]))
+    dcolorscale[index + 1,] <- c(nvals[i + 1], ifelse(discrete_colorbar, col_palette[index + 1], col_palette[i]))
   }
+
 
   # calculate tick values for legend (lowest point to max point)
   # works only with even spacing until now
   ticks <- seq.int(from = 1, to = max(bvals) * 2, by = 1)
+  range_min <- ifelse(discrete_colorbar, range_min, 1)
+  range_max <- ifelse(discrete_colorbar, range_max, max(bvals))
   # calc percentage of ticks * range (max - min) + min
   tick_vals <- (
     ticks[ticks %% 2 != 0] / max(ticks)
   ) * (
-    max(bvals) - min(utils::tail(bvals, -1))
-  ) + min(utils::tail(bvals, -1))
+    range_max - range_min
+  ) + range_min
 
   tick_text <- categories
 
@@ -50,43 +63,3 @@ discrete_coloring <- function(categories, col_palette) {
     )
   )
 }
-
-
-
-#  #' Generate Test Data
-#  #'
-#  #' @param nr_stops number of stops
-#  #' @param nr_drives number of drives
-#  #'
-#  #' @return tibble
-#  #'
-#  #' @export
-#  generate_test_data <- function(
-#    nr_stops=35,
-#    nr_drives=100
-#  ){
-#    # ---------------------------
-#    # generate data
-#    drive_ids <- sort(rep(seq(1, nr_drives), nr_stops))
-#    drive_names <- paste("Drive", drive_ids, sep = "_")
-#
-#    stop_ids <- rep(seq.int(1, nr_stops), nr_drives)
-#    stop_names <- paste("Stop", stop_ids, sep = "_")
-#
-#    nr_passengers = sample(1:50, nr_stops * nr_drives, replace=TRUE)
-#
-#    # ---------------------------
-#    # create input dataframe
-#    df <- dplyr::tibble(
-#      "Stop_id" = stop_ids,
-#      "Stop_names" = stop_names,
-#      "Drive_id" = drive_ids,
-#      "Drive_names" = drive_names,
-#      "Passengers" = nr_passengers,
-#      "Category" = ifelse(nr_passengers > 35, "high", ifelse(nr_passengers > 20, "medium", "low")),
-#      "Some_label" = rep("<b>Bla Label</b>", nr_stops * nr_drives)
-#    )
-#
-#    return(df)
-#  }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,6 @@ discrete_coloring <- function(categories, col_palette, range_min, range_max) {
     dcolorscale[index + 1,] <- c(nvals[i + 1], ifelse(discrete_colorbar, col_palette[index + 1], col_palette[i]))
   }
 
-
   # calculate tick values for legend (lowest point to max point)
   # works only with even spacing until now
   ticks <- seq.int(from = 1, to = max(bvals) * 2, by = 1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-catmaply <img src="man/figures/logo.png" align="right" height="192 px"/>
+catmaply
 ======================
 
 [![R build status](https://github.com/yvesmauron/catmaply/workflows/R-CMD-check/badge.svg)](https://github.com/yvesmauron/catmaply/actions) [![codecov](https://codecov.io/gh/yvesmauron/catmaply/branch/master/graph/badge.svg)](https://codecov.io/gh/yvesmauron/catmaply) [![](https://img.shields.io/badge/lifecycle-development-blue.svg)](https://www.tidyverse.org/lifecycle/#development)
@@ -8,7 +8,7 @@ catmaply <img src="man/figures/logo.png" align="right" height="192 px"/>
 
 A heatmap a graphical representation of data that uses a system of color-coding to represent different values. Heatmaps are used in various forms of analytics, however, this R package specifically focuses on providing an efficient way for creating interactive heatmaps for categorical data or continuous data that belongs to seperate groups/categories. 
 
-This package is originally beeing developed for Zurich Public Transport (VBZ) to illustrate the utilization of different routes and vehicles during different times of the day. It therefore groups utilization data (e.g. persons per m^2) into different categories (e.g. low, medium, high utilization) and plots it for certain stops over time in a heatmap.
+This package is originally beeing developed for Zurich Public Transport (VBZ) to illustrate the utilization of different routes and vehicles during different times of the day. It therefore groups utilization data (e.g. persons per m^2) into different categories (e.g. low, medium, high utilization) and plots it for certain stops over time in a heatmap using plotly.
 
 This package can easily be integrated into a shiny dashboard; which supports additional intactions with other plots (e.g. boxplot, histogram, forecast) by using plotly events. A mini-demo app is provided in a seperate github repository named [catmaply_shiny](https://github.com/yvesmauron/catmaply_shiny).
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     patch:
       default:
         threshold: 10%
+    patch:
+      default:
+        threshold: 2%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,4 @@ coverage:
   status:
     patch:
       default:
-        threshold: 6%
+        threshold: 10%

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,6 @@ coverage:
     patch:
       default:
         threshold: 10%
-    patch:
+    project:
       default:
         threshold: 2%

--- a/man/add_catmaply_single.Rd
+++ b/man/add_catmaply_single.Rd
@@ -7,9 +7,6 @@
 add_catmaply_single(
   fig,
   df,
-  x,
-  y,
-  z,
   hover_hide,
   color_palette,
   categorical_colorbar,
@@ -22,23 +19,11 @@ add_catmaply_single(
 
 \item{df}{data.frame or tibble holding the data.}
 
-\item{x}{column name holding the axis values for x.}
-
-\item{y}{column name holding the axis values for y.}
-
-\item{z}{column name holding the values for the fields.}
-
-\item{hover_hide}{boolean indicating if the hover label should be hidden or not; (default: FALSE).}
-
 \item{color_palette}{a color palette vector.}
-
-\item{categorical_colorbar}{if the resulting heatmap holds categorical field values or continuous values that belong to a category; (default: FALSE).}
 
 \item{legend_items}{distinct/unique items of ordered legend items}
 
 \item{legend}{boolean indicating if legend should be displayed or not; (default: TRUE).}
-
-\item{categorical_col}{if categorical_colorbar is TRUE, then this column is used to create categories; (default: FALSE).}
 }
 \value{
 plot_ly object

--- a/man/add_catmaply_traces.Rd
+++ b/man/add_catmaply_traces.Rd
@@ -7,9 +7,6 @@
 add_catmaply_traces(
   fig,
   df,
-  x,
-  y,
-  z,
   hover_hide,
   color_palette,
   categorical_colorbar,
@@ -21,12 +18,6 @@ add_catmaply_traces(
 \item{fig}{plotly object}
 
 \item{df}{data.frame or tibble holding the data.}
-
-\item{x}{column name holding the axis values for x.}
-
-\item{y}{column name holding the axis values for y.}
-
-\item{z}{column name holding the values for the fields.}
 
 \item{hover_hide}{boolean indicating if the hover label should be hidden or not; (default: FALSE).}
 

--- a/man/discrete_coloring.Rd
+++ b/man/discrete_coloring.Rd
@@ -4,12 +4,14 @@
 \alias{discrete_coloring}
 \title{Generates the parameters necessary for dicrete coloring and colorbar}
 \usage{
-discrete_coloring(categories, col_palette)
+discrete_coloring(categories, col_palette, range_min, range_max)
 }
 \arguments{
 \item{categories}{categories, for coloring should done}
 
 \item{col_palette}{the color palette}
+
+\item{range_min}{max of z range; (default: length(categories))}
 }
 \value{
 list(colorscale, tickvals, ticktext)

--- a/tests/testthat/test-catmaply.R
+++ b/tests/testthat/test-catmaply.R
@@ -462,4 +462,56 @@ test_that("test catmaply colorbar", {
       "plotly"
     )
   )
+
+  expect_true(
+    is(
+      catmaply(
+        df,
+        x='fahrt_seq',
+        x_order = 'fahrt_seq',
+        x_tickangle = -10,
+        y = "Haltestellenlangname",
+        y_order = "halt_seq",
+        z = "Besetzung",
+        categorical_colorbar = T,
+        categorical_col = 'Ausl_Kat',
+        color_palette = viridis::inferno,
+        legend_interactive = F,
+        legend = T
+      ),
+      "plotly"
+    )
+  )
+
+  expect_warning(
+    catmaply(
+      df,
+      x='fahrt_seq',
+      x_order = 'fahrt_seq',
+      x_tickangle = -10,
+      y = "Haltestellenlangname",
+      y_order = "halt_seq",
+      z = "Besetzung",
+      categorical_colorbar = T,
+      categorical_col = 'Ausl_Kat',
+      color_palette = viridis::inferno,
+      legend = F
+    )
+  )
+
+  expect_error(
+    catmaply(
+      df,
+      x='fahrt_seq',
+      x_order = 'fahrt_seq',
+      x_tickangle = -10,
+      y = "Haltestellenlangname",
+      y_order = "halt_seq",
+      z = "Besetzung",
+      categorical_colorbar = T,
+      categorical_col = 'Ausl_Kat',
+      color_palette = viridis::inferno(6),
+      legend = T
+    )
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,13 +1,15 @@
 # ---------------------------------------------
-# Testing plotting (rudimentary)
+# Testing plotting
 context("utils")
-
-categories <- paste("Category", seq.int(5))
-col_palette <- viridis::magma(length(categories))
 
 test_that("Test discrete_coloring", {
 
+  categories <- paste("Category", seq.int(5))
+  col_palette <- viridis::magma(length(categories))
+
   dc <- discrete_coloring(categories = categories, col_palette =  col_palette)
+
+  expect_true(is(dc, "list"))
 
   expect_true(length(dc) == 3)
 
@@ -24,4 +26,37 @@ test_that("Test discrete_coloring", {
   expect_error(discrete_coloring(categories[1:3], col_palette))
 
   expect_error(discrete_coloring(categories, col_palette[1:4]))
+
+})
+
+
+test_that("Test discrete_coloring with custom color ranges", {
+
+  data("vbz")
+
+  df <- vbz[[3]]$data
+
+  categories <- paste("Category", seq.int(5))
+  col_palette <- viridis::magma(length(categories) * 2)
+
+  dc <- discrete_coloring(categories = categories, col_palette =  col_palette, range_max = max(stats::na.omit(df$Besetzung)), range_min = min(stats::na.omit(df$Besetzung)))
+
+  expect_true(is(dc, "list"))
+
+  expect_true(length(dc) == 3)
+
+  expect_true(all(names(dc) %in% c("colorscale", "tickvals", "ticktext")))
+
+  expect_true(dim(dc$colorscale)[1] == length(categories) * 2)
+
+  expect_true(dim(dc$colorscale)[2] == 2)
+
+  expect_true(length(dc$tickvals) == length(categories) && length(dc$ticktext) == length(categories))
+
+  expect_true(all(categories == dc$ticktext))
+
+  expect_error(discrete_coloring(categories[1:3], col_palette))
+
+  expect_error(discrete_coloring(categories, col_palette[1:4]))
+
 })


### PR DESCRIPTION
- [x] add a color range per category similar to catmaply_traces
- [x] dynamically increase colorbar based on the number of elements displayed in it (not implemented in this release; check if users for feedback)

also; when using catmaply single without displaying the legend; warnings should be thrown that 

- [x] parameter categorical_colorbar will be ignored
- [x] parameter categorical_col will be ignored